### PR TITLE
chore(deps): bump idb-keyval from 3.2.0 to 5.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6180,9 +6180,9 @@
       }
     },
     "idb-keyval": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-3.2.0.tgz",
-      "integrity": "sha512-slx8Q6oywCCSfKgPgL0sEsXtPVnSbTLWpyiDcu6msHOyKOLari1TD1qocXVCft80umnkk3/Qqh3lwoFt8T/BPQ=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.0.5.tgz",
+      "integrity": "sha512-cqi65rrjhgPExI9vmSU7VcYEbHCUfIBY+9YUWxyr0PyGizptFgGFnvZQ0w+tqOXk1lUcGCZGVLfabf7QnR2S0g=="
     },
     "ieee754": {
       "version": "1.1.13",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/router": "~10.1.0",
     "@ngrx/effects": "^10.0.1",
     "@ngrx/store": "^10.0.1",
-    "idb-keyval": "^3.2.0",
+    "idb-keyval": "^5.0.5",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"

--- a/projects/ngrx-store-idb/package.json
+++ b/projects/ngrx-store-idb/package.json
@@ -16,7 +16,7 @@
     "@angular/core": "^10.1.6",
     "@ngrx/effects": "^10.0.1",
     "@ngrx/store": "^10.0.1",
-    "idb-keyval": "^3.2.0"
+    "idb-keyval": "^5.0.5"
   },
   "dependencies": {
     "deepmerge": "^4.2.2",

--- a/projects/ngrx-store-idb/src/lib/ngrx-store-idb.effects.ts
+++ b/projects/ngrx-store-idb/src/lib/ngrx-store-idb.effects.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType, OnInitEffects } from '@ngrx/effects';
 import { Action } from '@ngrx/store';
-import { get, Store } from 'idb-keyval';
+import { get, UseStore } from 'idb-keyval';
 import { from, of } from 'rxjs';
 import { catchError, map, mergeMap, tap } from 'rxjs/operators';
 import { rehydrateAction, rehydrateErrorAction, rehydrateInitAction } from './ngrx-store-idb.actions';
@@ -47,7 +47,7 @@ export class RehydrateEffects implements OnInitEffects {
   constructor(
     private actions$: Actions,
     @Inject(OPTIONS) private options: NgrxStoreIdbOptions,
-    @Inject(IDB_STORE) private idbStore: Store,
+    @Inject(IDB_STORE) private idbStore: UseStore,
   ) { }
 
   ngrxOnInitEffects(): Action {

--- a/projects/ngrx-store-idb/src/lib/ngrx-store-idb.metareducer.ts
+++ b/projects/ngrx-store-idb/src/lib/ngrx-store-idb.metareducer.ts
@@ -1,6 +1,6 @@
 import { ActionReducer, INIT, UPDATE } from '@ngrx/store';
 import * as deepmerge from 'deepmerge';
-import { set, Store } from 'idb-keyval';
+import { createStore, set, UseStore } from 'idb-keyval';
 import { rehydrateAction, RehydrateActionPayload, rehydrateErrorAction, rehydrateInitAction } from './ngrx-store-idb.actions';
 import { KeyConfiguration, Keys, NgrxStoreIdbOptions, SAVED_STATE_KEY } from './ngrx-store-idb.options';
 import { NgrxStoreIdbService } from './ngrx-store-idb.service';
@@ -133,7 +133,7 @@ const statesAreEqual = (prev: any, next: any): boolean => {
 /**
  * Method used to save actual state into IndexedDB
  */
-const syncStateUpdate = (state, action, opts: NgrxStoreIdbOptions, idbStore: Store, service: NgrxStoreIdbService) => {
+const syncStateUpdate = (state, action, opts: NgrxStoreIdbOptions, idbStore: UseStore, service: NgrxStoreIdbService) => {
   if (!service.canConcurrentlySync()) {
     if (opts.debugInfo) {
       console.debug('NgrxStoreIdb: State will not be persisted. Application runs also in other tab/window.');
@@ -197,7 +197,7 @@ const syncStateUpdate = (state, action, opts: NgrxStoreIdbOptions, idbStore: Sto
  * This is the main factory that creates our metareducer.
  */
 
-export const metaReducerFactoryWithOptions = (options: NgrxStoreIdbOptions, idbStore: Store, service: NgrxStoreIdbService) => {
+export const metaReducerFactoryWithOptions = (options: NgrxStoreIdbOptions, idbStore: UseStore, service: NgrxStoreIdbService) => {
   let rehydratedState = null;
   return (reducer: ActionReducer<any>) => (state: any, action) => {
     let nextState: any;
@@ -286,7 +286,7 @@ export const optionsFactory = (options: Partial<NgrxStoreIdbOptions>) => {
 };
 
 export const idbStoreFactory = (opts: NgrxStoreIdbOptions) => {
-  return new Store(opts.idb.dbName, opts.idb.storeName);
+  return createStore(opts.idb.dbName, opts.idb.storeName);
 };
 
 export const ngrxStoreIdbServiceInitializer = (opts: NgrxStoreIdbOptions, service: NgrxStoreIdbService) => {

--- a/projects/ngrx-store-idb/src/lib/ngrx-store-idb.options.ts
+++ b/projects/ngrx-store-idb/src/lib/ngrx-store-idb.options.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from '@angular/core';
 import { Action } from '@ngrx/store';
-import { Store } from 'idb-keyval';
+import { UseStore } from 'idb-keyval';
 
 /**
  * Injection token for injection options
@@ -10,7 +10,7 @@ export const OPTIONS = new InjectionToken<NgrxStoreIdbOptions>('NgrxStoreIdb opt
 /**
  * Injection token for injecting IDB store
  */
-export const IDB_STORE = new InjectionToken<Store>('IDB Store');
+export const IDB_STORE = new InjectionToken<UseStore>('IDB Store');
 
 /**
  * Name of the key in IndexedDB database store under which the state will be saved

--- a/projects/ngrx-store-idb/src/lib/ngrx-store-idb.service.ts
+++ b/projects/ngrx-store-idb/src/lib/ngrx-store-idb.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
 import { Action } from '@ngrx/store';
-import { get, set, Store } from 'idb-keyval';
+import { get, set, UseStore } from 'idb-keyval';
 import { EMPTY, from, Observable, ReplaySubject, timer } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { IDB_STORE, NgrxStoreIdbOptions, OPTIONS } from './ngrx-store-idb.options';
@@ -39,7 +39,7 @@ export class NgrxStoreIdbService {
 
   constructor(
     @Inject(OPTIONS) private opts: NgrxStoreIdbOptions,
-    @Inject(IDB_STORE) private idbStore: Store,
+    @Inject(IDB_STORE) private idbStore: UseStore,
   ) {
     this.uniqueKey = this.uuidv4();
 


### PR DESCRIPTION
I'm already using a later version of idb-keyval in my application, so I bumped the peer dependency to 5.0.5.

The two changes needed for this were `Store` -> `UseStore` and `new Store(...)` -> `createStore(...)`.

Feel free to merge if you'd like!