### PR TITLE
added version and migration configuration options

### DIFF
--- a/projects/ngrx-store-idb/src/lib/ngrx-store-idb.metareducer.ts
+++ b/projects/ngrx-store-idb/src/lib/ngrx-store-idb.metareducer.ts
@@ -2,7 +2,7 @@ import { ActionReducer, INIT, UPDATE } from '@ngrx/store';
 import deepmerge from 'deepmerge';
 import { createStore, set, UseStore } from 'idb-keyval';
 import { rehydrateAction, RehydrateActionPayload, rehydrateErrorAction, rehydrateInitAction } from './ngrx-store-idb.actions';
-import { KeyConfiguration, Keys, NgrxStoreIdbOptions, SAVED_STATE_KEY } from './ngrx-store-idb.options';
+import { KeyConfiguration, Keys, NgrxStoreIdbOptions, SAVED_STATE_KEY, SAVED_VERSION_KEY } from './ngrx-store-idb.options';
 import { NgrxStoreIdbService } from './ngrx-store-idb.service';
 
 /**
@@ -28,6 +28,7 @@ export const DEFAULT_OPTS: NgrxStoreIdbOptions = {
   unmarshaller: defaultUnmarshaller,
   marshaller: defaultMarshaller,
   debugInfo: true,
+  version: 0,
   idb: {
     dbName: 'NgrxStoreIdb',
     storeName: 'Store',
@@ -184,6 +185,12 @@ const syncStateUpdate = (state, action, opts: NgrxStoreIdbOptions, idbStore: Use
       if (opts.debugInfo) {
         console.debug('NgrxStoreIdb: Store state persisted to IndexedDB', marshalledState, action);
       }
+
+      return set(SAVED_VERSION_KEY, opts.version, idbStore).then(() => {
+        if (opts.debugInfo) {
+          console.debug('NgrxStoreIdb: Store version persisted to IndexedDb.', opts.version, action);
+        }
+      });
     })
     .catch(err => {
       if (opts.debugInfo) {

--- a/projects/ngrx-store-idb/src/lib/ngrx-store-idb.options.ts
+++ b/projects/ngrx-store-idb/src/lib/ngrx-store-idb.options.ts
@@ -17,6 +17,11 @@ export const IDB_STORE = new InjectionToken<UseStore>('IDB Store');
  */
 export const SAVED_STATE_KEY = 'State';
 
+/**
+ * Name of the key in IndexedDB database store under which the version will be saved
+ */
+export const SAVED_VERSION_KEY = 'Version';
+
 export interface KeyConfiguration {
   [key: string]: string[] | number[] | KeyConfiguration[];
 }
@@ -71,6 +76,16 @@ export interface NgrxStoreIdbOptions {
    * Can not be used together with keys.
    */
   marshaller: (state: any) => any;
+  /**
+   * If the stored state's version mismatch the one specified here, the storage will not be used.
+   * This is useful when adding a breaking change to your store.
+   */
+  version?: number
+  /**
+   * A function to perform persisted state migration.
+   * This function will be called when persisted state versions mismatch with the one specified here.
+   */
+  migrate?: (persistedState: any, version: number) => any
   /**
    * Print debug info if true
    */


### PR DESCRIPTION
This PR added two new configuration options that allow user to version their saved state and migrate when they introduced breaking changes to the state schema: 
* `version`
* `migrate`

The idea is borrowed from Zustand:
* doc: https://github.com/pmndrs/zustand/blob/main/docs/integrations/persisting-store-data.md#version
* source code: https://github.com/pmndrs/zustand/blob/main/src/middleware/persist.ts

I've tested this locally. 