### PR TITLE
feat(init): broadcast event when rehydrate is done

### DIFF
--- a/projects/ngrx-store-idb/src/lib/ngrx-store-idb.actions.ts
+++ b/projects/ngrx-store-idb/src/lib/ngrx-store-idb.actions.ts
@@ -7,3 +7,4 @@ export interface RehydrateActionPayload {
 export const rehydrateInitAction = createAction('NgrxStoreIdb/Init');
 export const rehydrateAction = createAction('NgrxStoreIdb/Rehydrate', props<RehydrateActionPayload>());
 export const rehydrateErrorAction = createAction('NgrxStoreIdb/RehydrateError');
+export const rehydrateDoneAction = createAction('NgrxStoreIdb/RehydrateDone');

--- a/projects/ngrx-store-idb/src/lib/ngrx-store-idb.module.ts
+++ b/projects/ngrx-store-idb/src/lib/ngrx-store-idb.module.ts
@@ -9,7 +9,7 @@ import { NgrxStoreIdbService } from './ngrx-store-idb.service';
 
 /**
  * Import this module in your AppModule using forRoot() method to
- * enable synchornisation of redux store with IndexedDB.
+ * enable synchronisation of redux store with IndexedDB.
  */
 @NgModule({
   declarations: [],


### PR DESCRIPTION
This PR broadcasts an event when the first rehydratation is done (successfully or with error). 
This allows developers to subscribe to a “store rehydratation from idb done” event, required in some on app data bootstrap scenarios





